### PR TITLE
Fix permissions issue with generated file from 0777 to 0644

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 				return fmt.Errorf("Error while generating enums\nInputFile=%s\nError=%s\n", ctx.Color().Cyan(fileName), ctx.Color().RedBg(err))
 			}
 
-			err = ioutil.WriteFile(outFilePath, raw, os.ModePerm)
+			mode := int(0644)
+			err = ioutil.WriteFile(outFilePath, raw, os.FileMode(mode))
 			if err != nil {
 				return fmt.Errorf("Error while writing to file %s: %s\n", ctx.Color().Cyan(outFilePath), ctx.Color().Red(err))
 			}


### PR DESCRIPTION
`os.ModePerm` is `0777` which creates an executable file, which fails `golint`. This file doesn't need to be executable as far as I can tell so `0664` seems like it would be safer. 