### PR TITLE
Generated Parse template with proper punctuation

### DIFF
--- a/generator/enum.tmpl
+++ b/generator/enum.tmpl
@@ -40,7 +40,7 @@ func (x {{.enum.Name}}) String() string {
 
 var _{{.enum.Name}}Value = {{ unmapify .enum .lowercase }}
 
-// Parse{{.enum.Name}} attempts to convert a string to a {{.enum.Name}}
+// Parse{{.enum.Name}} attempts to convert a string to a {{.enum.Name}}.
 func Parse{{.enum.Name}}(name string) ({{.enum.Name}}, error) {
 	if x, ok := _{{.enum.Name}}Value[name]; ok {
 		return x, nil


### PR DESCRIPTION
Based on [effective Go](https://go.dev/doc/effective_go#commentary) (and the pattern also found elsewhere here :), comments should be full sentences and punctuated as such.