### PR TITLE
Fix ignoring text after closing ) also for single line ENUM

### DIFF
--- a/generator/example_test.go
+++ b/generator/example_test.go
@@ -21,7 +21,7 @@ type Color int
 // ) Some other line of info
 type Animal int32
 
-// Model x ENUM(Toyota,_,Chevy,_,Ford)
+// Model x ENUM(Toyota,_,Chevy,_,Ford).
 type Model int32
 
 /* ENUM(

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -572,7 +572,14 @@ func breakCommentIntoLines(comment *ast.Comment) []string {
 
 // trimAllTheThings takes off all the cruft of a line that we don't need.
 func trimAllTheThings(thing string) string {
-	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(thing), `,`), `)`))
+	preTrimmed := strings.TrimSuffix(strings.TrimSpace(thing), `,`)
+	end := strings.Index(preTrimmed, `)`)
+
+	if end < 0 {
+		end = len(preTrimmed)
+	}
+
+	return strings.TrimSpace(preTrimmed[:end])
 }
 
 // inspect will walk the ast and fill a map of names and their struct information


### PR DESCRIPTION
When trying out 0.4.2 locally, I noticed that while multi-line comments worked fine with trailing text, singleline ENUM specifications failed.

The altered test case fails without the addition in `trimAllTheThings`, possibly some of the previous fixes in https://github.com/abice/go-enum/commit/fa188db43bd040a7fe6c2bcedd699b757ae6cb0b are now redundant.