### PR TITLE
Add support for case changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ GLOBAL OPTIONS:
    --flag                      Adds golang flag functions. (default: false)
    --prefix value              Replaces the prefix with a user one.
    --names                     Generates a 'Names() []string' function, and adds the possible enum values in the error response during parsing (default: false)
+   --nolower                   Remove the UPPERCASE to lowercase name change (default: false)
    --nocamel                   Removes the snake_case to CamelCase name changing (default: false)
    --ptr                       Adds a pointer method to get a pointer from const values (default: false)
    --sqlnullint                Adds a Null{{ENUM}} type for marshalling a nullable int value to sql (default: false)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -44,6 +44,7 @@ type Generator struct {
 	sql               bool
 	flag              bool
 	names             bool
+	leaveLowerCase    bool
 	leaveSnakeCase    bool
 	prefix            string
 	sqlNullInt        bool
@@ -145,7 +146,13 @@ func (g *Generator) WithNames() *Generator {
 	return g
 }
 
-// WithoutSnakeToCamel is used to add flag methods to the enum
+// WithoutUpperToLower is used to remove the UPPERCASE to lowercase name changing
+func (g *Generator) WithoutUpperToLower() *Generator {
+	g.leaveLowerCase = true
+	return g
+}
+
+// WithoutSnakeToCamel is used to remove the snake_case to CamelCase name changing
 func (g *Generator) WithoutSnakeToCamel() *Generator {
 	g.leaveSnakeCase = true
 	return g
@@ -413,6 +420,9 @@ func (g *Generator) parseEnum(ts *ast.TypeSpec) (*Enum, error) {
 			if name != skipHolder {
 				prefixedName = enum.Prefix + name
 				prefixedName = sanitizeValue(prefixedName)
+				if !g.leaveLowerCase {
+					prefixedName = upperToLowerCase(prefixedName)
+				}
 				if !g.leaveSnakeCase {
 					prefixedName = snakeToCamelCase(prefixedName)
 				}
@@ -488,6 +498,10 @@ func snakeToCamelCase(value string) string {
 	value = strings.Join(parts, "")
 
 	return value
+}
+
+func upperToLowerCase(value string) string{
+	return strings.Lowercase(value)
 }
 
 // getEnumDeclFromComments parses the array of comment strings and creates a single Enum Declaration statement

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type rootT struct {
 	Flag              bool
 	Prefix            string
 	Names             bool
+	LeaveLowerCase    bool
 	LeaveSnakeCase    bool
 	SQLNullStr        bool
 	SQLNullInt        bool
@@ -100,6 +101,11 @@ func main() {
 				Name:        "names",
 				Usage:       "Generates a 'Names() []string' function, and adds the possible enum values in the error response during parsing",
 				Destination: &argv.Names,
+			},
+			&cli.BoolFlag{
+				Name:        "nolower",
+				Usage:       "Remove the UPPERCASE to lowercase name change",
+				Destination: &argv.LeaveLowerCase,
 			},
 			&cli.BoolFlag{
 				Name:        "nocamel",
@@ -176,6 +182,9 @@ func main() {
 				}
 				if argv.Names {
 					g.WithNames()
+				}
+				if argv.LeaveLowerCase {
+					g.WithoutUpperToLower()
 				}
 				if argv.LeaveSnakeCase {
 					g.WithoutSnakeToCamel()


### PR DESCRIPTION
The main reason behind this PR is I often have my enums defined as upper snake case like this: `MY_ENUM`. This means when I run the generator the constant generated is `EnumTypeMYENUM`, instead of `EnumTypeMyEnum` as expected.

Note: the lowercase name transformation is applied before the CamelCase transformation.

## Example

### Declaration:
```go
// ENUM(MY_ENUM)
type EnumType int
```

### Before this PR:

Generated Constant
```go
const (
	// EnumTypeMYENUM is a EnumType of type MY_ENUM.
	EnumTypeMYENUM = iota
)
```

### After this PR:

Generated Constant
```go
const (
	// EnumTypeMyEnum is a EnumType of type MY_ENUM.
	EnumTypeMyEnum = iota
)