### PR TITLE
Use GOFILE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ I did not specify any overrides on the release binary names, so `uname -s` and `
 
 ### Using go generate
 
-1. Add a go:generate line to your file like so... `//go:generate go-enum -f=$GOFILE --marshal`
+1. Add a go:generate line to your file like so... `//go:generate go-enum --marshal`
 1. Run go generate like so `go generate ./...`
 1. Enjoy your newly created Enumeration!
 

--- a/_example/animal.go
+++ b/_example/animal.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE -a "+:Plus,#:Sharp"
+//go:generate ../bin/go-enum -a "+:Plus,#:Sharp"
 
 package example
 

--- a/_example/color.go
+++ b/_example/color.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --marshal --lower --ptr --mustparse
+//go:generate ../bin/go-enum  --marshal --lower --ptr --mustparse
 
 package example
 

--- a/_example/commented.go
+++ b/_example/commented.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --marshal --lower
+//go:generate ../bin/go-enum --marshal --lower
 
 package example
 

--- a/_example/custom_prefix.go
+++ b/_example/custom_prefix.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --prefix=AcmeInc
+//go:generate ../bin/go-enum  --prefix=AcmeInc
 
 package example
 

--- a/_example/enum_32_bit.go
+++ b/_example/enum_32_bit.go
@@ -1,8 +1,9 @@
-//go:generate ../bin/go-enum -f=$GOFILE --names
+//go:generate ../bin/go-enum --names
 
 package example
 
-/* ENUM(
+/*
+ENUM(
 
 Unkno					= 0
 E2P15					= 32768
@@ -18,6 +19,5 @@ E2P28					= 536870912
 E2P30					= 1073741824
 
 )
-
 */
 type Enum32bit uint32

--- a/_example/enum_64_bit.go
+++ b/_example/enum_64_bit.go
@@ -1,10 +1,10 @@
-//go:generate ../bin/go-enum -f=$GOFILE --names
+//go:generate ../bin/go-enum  --names
 
 package example
 
-/* ENUM(
-
-Unkno 				= 0
+/*
+ENUM(
+Unkno					= 0
 E2P15					= 32768
 E2P16					= 65536
 E2P17					= 131072
@@ -21,6 +21,5 @@ E2P32					= 4294967296
 E2P33					= 8454967296
 E2P63					= 18446744073709551615
 )
-
 */
 type Enum64bit uint64

--- a/_example/example.go
+++ b/_example/example.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --marshal --nocase --flag --names
+//go:generate ../bin/go-enum --marshal --nocase --flag --names
 
 package example
 

--- a/_example/force_lower.go
+++ b/_example/force_lower.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --forcelower
+//go:generate ../bin/go-enum  --forcelower
 
 package example
 

--- a/_example/negative.go
+++ b/_example/negative.go
@@ -1,8 +1,9 @@
-//go:generate ../bin/go-enum -f=$GOFILE --nocase
+//go:generate ../bin/go-enum  --nocase
 
 package example
 
-/* ENUM(
+/*
+ENUM(
 Unknown = -1,
 Good,
 Bad
@@ -10,7 +11,8 @@ Bad
 */
 type Status int
 
-/* ENUM(
+/*
+ENUM(
 Unknown = -5,
 Good,
 Bad,

--- a/_example/replace_prefix.go
+++ b/_example/replace_prefix.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --marshal --prefix=AcmeInc_ --noprefix --nocamel --names
+//go:generate ../bin/go-enum  --marshal --prefix=AcmeInc_ --noprefix --nocamel --names
 
 package example
 

--- a/_example/replace_prefix_int.go
+++ b/_example/replace_prefix_int.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --marshal --prefix=AcmeInt_ --noprefix --nocamel --names
+//go:generate ../bin/go-enum  --marshal --prefix=AcmeInt_ --noprefix --nocamel --names
 
 package example
 

--- a/_example/sql.go
+++ b/_example/sql.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --sql --sqlnullstr --sqlnullint --ptr --marshal
+//go:generate ../bin/go-enum  --sql --sqlnullstr --sqlnullint --ptr --marshal
 
 package example
 

--- a/_example/sql_int.go
+++ b/_example/sql_int.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --sqlnullint
+//go:generate ../bin/go-enum  --sqlnullint
 
 package example
 

--- a/_example/sql_str.go
+++ b/_example/sql_str.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --sql --sqlnullstr
+//go:generate ../bin/go-enum  --sql --sqlnullstr
 
 package example
 

--- a/_example/strings_only.go
+++ b/_example/strings_only.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE --ptr --marshal --flag --nocase --mustparse --sqlnullstr --sql --names
+//go:generate ../bin/go-enum  --ptr --marshal --flag --nocase --mustparse --sqlnullstr --sql --names
 
 package example
 

--- a/_example/user_template.go
+++ b/_example/user_template.go
@@ -1,4 +1,4 @@
-//go:generate ../bin/go-enum -f=$GOFILE -t user_template.tmpl -t *user_glob*.tmpl
+//go:generate ../bin/go-enum  -t user_template.tmpl -t *user_glob*.tmpl
 
 package example
 

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:        "file",
 				Aliases:     []string{"f"},
+				EnvVars:     []string{"GOFILE"},
 				Usage:       "The file(s) to generate enums.  Use more than one flag for more files.",
 				Required:    true,
 				Destination: &argv.FileNames,


### PR DESCRIPTION
Adds `GOFILE` env var to the CLI config so that the file flag not required when using `//go:generate`.