### PR TITLE
fix: fixed generation of string enums with one char being a backtick, single quote or double quote

### DIFF
--- a/generator/enum_string.tmpl
+++ b/generator/enum_string.tmpl
@@ -10,7 +10,7 @@ const (
 	{{- if $value.Comment}}
 	// {{$value.Comment}}
 	{{- end}}
-    {{$value.PrefixedName}} {{$enumName}} = "{{$value.ValueStr}}"
+    {{$value.PrefixedName}} {{$enumName}} = {{quote $value.ValueStr}}
 {{- end}}
 )
 {{if .names -}}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -389,3 +389,54 @@ func TestQuotedStrings(t *testing.T) {
 		fmt.Println(string(output))
 	}
 }
+
+func TestStringWithSingleDoubleQuoteValue(t *testing.T) {
+	input := `package test
+	// ENUM(DoubleQuote='"')
+	type Char string
+	`
+	g := NewGenerator()
+	f, err := parser.ParseFile(g.fileSet, "TestRequiredErrors", input, parser.ParseComments)
+	assert.Nil(t, err, "Error parsing no struct input")
+
+	output, err := g.Generate(f)
+	assert.Nil(t, err, "Error generating formatted code")
+	assert.Contains(t, string(output), "CharDoubleQuote Char = \"\\\"\"")
+	if false { // Debugging statement
+		fmt.Println(string(output))
+	}
+}
+
+func TestStringWithSingleSingleQuoteValue(t *testing.T) {
+	input := `package test
+	// ENUM(SingleQuote="'")
+	type Char string
+	`
+	g := NewGenerator()
+	f, err := parser.ParseFile(g.fileSet, "TestRequiredErrors", input, parser.ParseComments)
+	assert.Nil(t, err, "Error parsing no struct input")
+
+	output, err := g.Generate(f)
+	assert.Nil(t, err, "Error generating formatted code")
+	assert.Contains(t, string(output), "CharSingleQuote Char = \"'\"")
+	if false { // Debugging statement
+		fmt.Println(string(output))
+	}
+}
+
+func TestStringWithSingleBacktickValue(t *testing.T) {
+	input := `package test
+	// ENUM(SingleQuote="` + "`" + `")
+	type Char string
+	`
+	g := NewGenerator()
+	f, err := parser.ParseFile(g.fileSet, "TestRequiredErrors", input, parser.ParseComments)
+	assert.Nil(t, err, "Error parsing no struct input")
+
+	output, err := g.Generate(f)
+	assert.Nil(t, err, "Error generating formatted code")
+	assert.Contains(t, string(output), "CharSingleQuote Char = \"`\"")
+	if false { // Debugging statement
+		fmt.Println(string(output))
+	}
+}


### PR DESCRIPTION
I'm writing some constants for working with a PDF.
A PDF has the operators `'` and `"`, when I tried to create constants for these operators it would generated an invalid file.
The constant value would be correct, like `OPMoveToNextLineSetSpacingShowText OP = "\""`, which is valid, but in the `_OPValue` map it would create a key with the value `"\\\""`, which is invalid.
I updated the code to fix that. It passes all the previous tests and now it generates the proper value and the proper key.