### PR TITLE
add custom json package for imports instead encoding/json support

### DIFF
--- a/example/sql_enum.go
+++ b/example/sql_enum.go
@@ -11,7 +11,7 @@ package example
 
 import (
 	"database/sql/driver"
-	"encoding/json"
+	json "encoding/json"
 	"errors"
 	"fmt"
 	"strconv"

--- a/example/strings_only_enum.go
+++ b/example/strings_only_enum.go
@@ -11,7 +11,7 @@ package example
 
 import (
 	"database/sql/driver"
-	"encoding/json"
+	json "encoding/json"
 	"errors"
 	"fmt"
 	"strings"

--- a/generator/.snapshots/Test118CustomPrefixExampleFile-1.18
+++ b/generator/.snapshots/Test118CustomPrefixExampleFile-1.18
@@ -9,7 +9,7 @@
   (string) "",
   (string) (len=8) "import (",
   (string) (len=22) "\t\"database/sql/driver\"",
-  (string) (len=16) "\t\"encoding/json\"",
+  (string) (len=21) "\tjson \"encoding/json\"",
   (string) (len=9) "\t\"errors\"",
   (string) (len=6) "\t\"fmt\"",
   (string) (len=10) "\t\"strconv\"",

--- a/generator/.snapshots/Test118CustomPrefixExampleFile-og
+++ b/generator/.snapshots/Test118CustomPrefixExampleFile-og
@@ -9,7 +9,7 @@
   (string) "",
   (string) (len=8) "import (",
   (string) (len=22) "\t\"database/sql/driver\"",
-  (string) (len=16) "\t\"encoding/json\"",
+  (string) (len=21) "\tjson \"encoding/json\"",
   (string) (len=9) "\t\"errors\"",
   (string) (len=6) "\t\"fmt\"",
   (string) (len=10) "\t\"strconv\"",

--- a/generator/.snapshots/TestCustomPrefixExampleFile
+++ b/generator/.snapshots/TestCustomPrefixExampleFile
@@ -9,7 +9,7 @@
   (string) "",
   (string) (len=8) "import (",
   (string) (len=22) "\t\"database/sql/driver\"",
-  (string) (len=16) "\t\"encoding/json\"",
+  (string) (len=21) "\tjson \"encoding/json\"",
   (string) (len=9) "\t\"errors\"",
   (string) (len=6) "\t\"fmt\"",
   (string) (len=10) "\t\"strconv\"",

--- a/generator/enum.tmpl
+++ b/generator/enum.tmpl
@@ -13,6 +13,7 @@ package {{.package}}
 
 import (
     "fmt"
+	json "{{.jsonpkg}}"
 )
 {{end -}}
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -45,6 +45,7 @@ type Generator struct {
 	names             bool
 	values            bool
 	leaveSnakeCase    bool
+	jsonPkg           string
 	prefix            string
 	sqlNullInt        bool
 	sqlNullStr        bool
@@ -90,6 +91,7 @@ func NewGenerator() *Generator {
 		fileSet:           token.NewFileSet(),
 		noPrefix:          false,
 		replacementNames:  map[string]string{},
+		jsonPkg:           "encoding/json",
 	}
 
 	funcs := sprig.TxtFuncMap()
@@ -168,6 +170,12 @@ func (g *Generator) WithValues() *Generator {
 // WithoutSnakeToCamel is used to add flag methods to the enum
 func (g *Generator) WithoutSnakeToCamel() *Generator {
 	g.leaveSnakeCase = true
+	return g
+}
+
+// WithJsonPkg is used to add a custom json package to the imports
+func (g *Generator) WithJsonPkg(pkg string) *Generator {
+	g.jsonPkg = pkg
 	return g
 }
 
@@ -295,6 +303,7 @@ func (g *Generator) Generate(f *ast.File) ([]byte, error) {
 		"buildDate": g.BuildDate,
 		"builtBy":   g.BuiltBy,
 		"buildTags": g.buildTags,
+		"jsonpkg":   g.jsonPkg,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed writing header: %w", err)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ type rootT struct {
 	SQL               bool
 	SQLInt            bool
 	Flag              bool
+	JsonPkg           string
 	Prefix            string
 	Names             bool
 	Values            bool
@@ -101,6 +102,11 @@ func main() {
 				Name:        "flag",
 				Usage:       "Adds golang flag functions.",
 				Destination: &argv.Flag,
+			},
+			&cli.StringFlag{
+				Name:        "jsonpkg",
+				Usage:       "Custom json package for imports instead encoding/json.",
+				Destination: &argv.JsonPkg,
 			},
 			&cli.StringFlag{
 				Name:        "prefix",
@@ -226,6 +232,9 @@ func main() {
 				}
 				if argv.LeaveSnakeCase {
 					g.WithoutSnakeToCamel()
+				}
+				if argv.JsonPkg != "" {
+					g.WithJsonPkg(argv.JsonPkg)
 				}
 				if argv.Prefix != "" {
 					g.WithPrefix(argv.Prefix)


### PR DESCRIPTION
- add custom json package for imports instead encoding/json support.

Usage:
```go
//go:generate go-enum --marshal --sqlnullint --jsonpkg github.com/alimy/typst/json

/*
RunStatus
ENUM(

	None, // 未知
	Idle, // 空闲
	Pending, // 待命状态
	Processing, // 正在处理

)
*/
type RunStatus int
```

Will generate code like below:
```go
package enum

import (
	"database/sql/driver"
	"errors"
	"fmt"
	"strconv"

	json "github.com/alimy/typst/json"
)

// other code
...

// MarshalJSON correctly serializes a NullRunStatus to JSON.
func (n NullRunStatus) MarshalJSON() ([]byte, error) {
	const nullStr = "null"
	if n.Valid {
		return json.Marshal(n.RunStatus)
	}
	return []byte(nullStr), nil
}

// UnmarshalJSON correctly deserializes a NullRunStatus from JSON.
func (n *NullRunStatus) UnmarshalJSON(b []byte) error {
	n.Set = true
	var x interface{}
	err := json.Unmarshal(b, &x)
	if err != nil {
		return err
	}
	err = n.Scan(x)
	return err
}