### PR TITLE
feat: get version info from go runtime

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -725,11 +725,12 @@ func TestCliFlagAliases(t *testing.T) {
 }
 
 func TestGlobalVariables(t *testing.T) {
+	initializeVersion()
 	// Test that global variables are properly declared
-	assert.Equal(t, "", version) // Should be empty by default (set during build)
-	assert.Equal(t, "", commit)  // Should be empty by default (set during build)
-	assert.Equal(t, "", date)    // Should be empty by default (set during build)
-	assert.Equal(t, "", builtBy) // Should be empty by default (set during build)
+	assert.Equal(t, "(devel)", version)    // Default is "(devel)" unless set during build
+	assert.Equal(t, "", commit)            // Should be empty by default (set during build)
+	assert.Equal(t, "", date)              // Should be empty by default (set during build)
+	assert.Equal(t, "go install", builtBy) // Default is "go install" unless set during build
 }
 
 func TestGlobFilenamesEdgeCases(t *testing.T) {


### PR DESCRIPTION
Fixes #279

Didn't realize go has a way to grab build info from the runtime, pretty neat!

This pull request introduces functionality to initialize and manage versioning metadata for the application. The most important changes include adding a new `initializeVersion` function to extract build information and modifying the `main` function to invoke this new functionality.

### Versioning functionality:

* **Added `initializeVersion` function**: This function uses the `debug.ReadBuildInfo` method to retrieve build metadata, including version, commit hash, build date, and whether the source was modified. The metadata is stored in global variables for use across the application. (`main.go`, [main.goR51-R81](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R51-R81))
* **Imported `runtime/debug` package**: This import enables the use of `debug.ReadBuildInfo` for accessing build metadata. (`main.go`, [main.goR8](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R8))

### Code refinement:

* **Updated `out` function signature**: Changed the variadic parameter type from `interface{}` to `any`, aligning with Go's updated type alias for improved readability. (`main.go`, [main.goR51-R81](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R51-R81))