### PR TITLE
fix: build issue

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,15 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.22'
-          - '1.23'
-          - '1.24'
+          - "1.24"
+          - "1.25"
     name: run tests with go version ${{ matrix.go }}
     steps:
       - name: install go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '${{ matrix.go }}'
+          go-version: "${{ matrix.go }}"
           check-latest: true
 
       - name: checkout code
@@ -33,7 +32,7 @@ jobs:
       - name: Test
         run: |
           make cover
-      
+
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         with:
@@ -49,7 +48,7 @@ jobs:
 
       - name: Assert no changes
         run: make assert-no-changes
-  
+
   # notifies that all test jobs are finished.
   finish:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ">=1.23.2"
       - name: Ensure Go

--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ">=1.23.2"
       - name: Ensure Go
@@ -33,7 +33,7 @@ jobs:
           distribution: goreleaser
           version: latest
           args: check
-          
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to use newer Go versions and the latest setup-go action. The main changes are upgrading the Go versions used in CI and switching from `actions/setup-go@v5` to `actions/setup-go@v6` in all workflows.

**CI/CD Workflow Updates:**

* Updated the Go versions in the test matrix to use `"1.24"` and add `"1.25"`, removing older versions (`1.22` and `1.23`) in `.github/workflows/build_and_test.yml`.
* Upgraded the `actions/setup-go` action from `v5` to `v6` in `.github/workflows/build_and_test.yml`, `.github/workflows/release.yml`, and `.github/workflows/release_check.yml` for improved reliability and compatibility. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L16-R23) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L18-R18) [[3]](diffhunk://#diff-5faca5b57338b336086d1f0191c5454af746fc9661c5734f7e4a2fa6a078621aL16-R16)